### PR TITLE
Added webhook functionality to the CLI

### DIFF
--- a/init.go
+++ b/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/centurylinkcloud/clc-go-cli/models/ospatch"
 	"github.com/centurylinkcloud/clc-go-cli/models/server"
 	"github.com/centurylinkcloud/clc-go-cli/models/vpn"
+	"github.com/centurylinkcloud/clc-go-cli/models/webhook"
 )
 
 var AllCommands []base.Command = make([]base.Command, 0)
@@ -3724,6 +3725,91 @@ func init() {
 				{
 					"--vpn-id",
 					[]string{"Required. ID of the VPN."},
+				},
+			},
+		},
+	})
+	registerCommandBase(nil, &webhook.ListRes{}, commands.CommandExcInfo{
+		Verb:     "GET",
+		Url:      "https://api.ctl.io/v2/webhooks/{accountAlias}",
+		Resource: "webhook",
+		Command:  "list",
+		Help: help.Command{
+			Brief: []string{"Gets a list of the webhooks configured for a given account."},
+		},
+	})
+	registerCommandBase(&webhook.DeleteReq{}, new(string), commands.CommandExcInfo{
+		Verb:     "DELETE",
+		Url:      "https://api.ctl.io/v2/webhooks/{accountAlias}/{Event}/configuration",
+		Resource: "webhook",
+		Command:  "delete",
+		Help: help.Command{
+			Brief: []string{"Deletes a given alert policy by ID."},
+			Arguments: []help.Argument{
+				{
+					"--event",
+					[]string{"Required. Name of the event for which the webhook will be deleted."},
+				},
+			},
+		},
+	})
+	registerCommandBase(&webhook.DeleteTargetURIReq{}, new(string), commands.CommandExcInfo{
+		Verb:     "DELETE",
+		Url:      "https://api.ctl.io/v2/webhooks/{accountAlias}/{Event}/configuration/targetUris?targetUri={TargetUri}",
+		Resource: "webhook",
+		Command:  "delete-targeturi",
+		Help: help.Command{
+			Brief: []string{"Deletes a target URI from a webhook."},
+			Arguments: []help.Argument{
+				{
+					"--event",
+					[]string{"Required. Name of the event for which the target URI will be deleted."},
+				},
+				{
+					"--target-uri",
+					[]string{"The URI of the target to remove from the webhook."},
+				},
+			},
+		},
+	})
+	registerCommandBase(&webhook.AddTargetURIReq{}, new(string), commands.CommandExcInfo{
+		Verb:     "POST",
+		Url:      "https://api.ctl.io/v2/webhooks/{accountAlias}/{Event}/configuration/targetUris",
+		Resource: "webhook",
+		Command:  "add-targeturi",
+		Help: help.Command{
+			Brief: []string{"Add a target uri to the webhook for a specified event."},
+			Arguments: []help.Argument{
+				{
+					"--event",
+					[]string{"Required. Name of the event for which the target URI will be added."},
+				},
+				{
+					"--target-uri",
+					[]string{"Required. A uri that will be called when the event occurs."},
+				},
+			},
+		},
+	})
+	registerCommandBase(&webhook.UpdateReq{}, new(string), commands.CommandExcInfo{
+		Verb:     "PUT",
+		Url:      "https://api.ctl.io/v2/webhooks/{accountAlias}/{Event}/configuration",
+		Resource: "webhook",
+		Command:  "update",
+		Help: help.Command{
+			Brief: []string{"Change the configuration of a webhook for a specific event."},
+			Arguments: []help.Argument{
+				{
+					"--event",
+					[]string{"Required. Name of the event for which to update the webhook."},
+				},
+				{
+					"--recursive",
+					[]string{"Required. If true, the webhook is called when the event occurs in sub-accounts."},
+				},
+				{
+					"--target-uri",
+					[]string{"A uri that will be called when the event occurs."},
 				},
 			},
 		},

--- a/models/webhook/add-targeturi.go
+++ b/models/webhook/add-targeturi.go
@@ -1,0 +1,23 @@
+package webhook
+
+// AddTargetURIReq represents a request to add a webhook. It will add a target uri to be called on a specific event.
+type AddTargetURIReq struct {
+	Event     string `json:"-" valid:"required" URIParam:"yes"`
+	TargetUri string `valid:"required" json:"targetUri"`
+}
+
+// Validate provides custom validation for the AddTargetURIReq request
+func (c *AddTargetURIReq) Validate() error {
+
+	err := ValidateTargetURI(c.TargetUri)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateEvent(c.Event)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/webhook/delete-targeturi.go
+++ b/models/webhook/delete-targeturi.go
@@ -1,0 +1,23 @@
+package webhook
+
+// DeleteTargetURIReq represents a request to delete a specific target uri associated with a webhook for a given event
+type DeleteTargetURIReq struct {
+	Event     string `json:"-" valid:"required" URIParam:"yes"`
+	TargetUri string `URIParam:"yes" valid:"required"`
+}
+
+// Validate provides custom validation for the DeleteTargetURIReq request
+func (c *DeleteTargetURIReq) Validate() error {
+
+	err := ValidateTargetURI(c.TargetUri)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateEvent(c.Event)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/webhook/delete.go
+++ b/models/webhook/delete.go
@@ -1,0 +1,17 @@
+package webhook
+
+// DeleteReq represents a request to delete all the target uris associated with a webhook for a given event
+type DeleteReq struct {
+	Event string `json:"-" valid:"required" URIParam:"yes"`
+}
+
+// Validate provides custom validation for the AddTargetURIReq request
+func (c *DeleteReq) Validate() error {
+
+	err := ValidateEvent(c.Event)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/webhook/entities.go
+++ b/models/webhook/entities.go
@@ -1,0 +1,20 @@
+package webhook
+
+import (
+	"github.com/centurylinkcloud/clc-go-cli/models"
+)
+
+type Webhook struct {
+	Name          string
+	Configuration Configuration
+	Links         []models.LinkEntity
+}
+
+type Configuration struct {
+	Recursive  bool
+	TargetUris []TargetUri
+}
+
+type TargetUri struct {
+	TargetUri string
+}

--- a/models/webhook/list.go
+++ b/models/webhook/list.go
@@ -1,0 +1,6 @@
+package webhook
+
+// ListRes represents a list of webhooks
+type ListRes struct {
+	Items []Webhook
+}

--- a/models/webhook/update.go
+++ b/models/webhook/update.go
@@ -1,0 +1,31 @@
+package webhook
+
+// UpdateReq represents a request to update a webhook for a given event
+type UpdateReq struct {
+	Event      string      `json:"-" valid:"required" URIParam:"yes"`
+	Recursive  string      `json:"recursive" oneOf:"true,false"`
+	TargetUris []TargetUri `json:"targetUris,omitempty"`
+}
+
+// Validate provides custom validation for the UpdateReq request
+func (c *UpdateReq) Validate() error {
+
+	if c.TargetUris != nil {
+		if len(c.TargetUris) > 0 {
+
+			for _, targetURI := range c.TargetUris {
+				err := ValidateTargetURI(targetURI.TargetUri)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	err := ValidateEvent(c.Event)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/webhook/validation.go
+++ b/models/webhook/validation.go
@@ -1,0 +1,48 @@
+package webhook
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/asaskevich/govalidator"
+)
+
+var allowedEvents = []string{
+	"Account.Created", "Account.Deleted", "Account.Updated", "Alert.Notification", "Server.Created", "Server.Deleted", "Server.Updated",
+	"User.Created", "User.Deleted", "User.Updated"}
+
+// ValidateTargetURI provides validation checks for the targetUri of a webhook
+func ValidateTargetURI(targetURI string) error {
+
+	validURL := govalidator.IsURL(targetURI)
+	if !validURL {
+		return fmt.Errorf("TargetUri: invalid URI.")
+	}
+
+	url, _ := url.Parse(targetURI)
+	if strings.ToLower(url.Scheme) != "https" {
+		return fmt.Errorf("TargetUri: must be an HTTPS endpoint.")
+	}
+
+	return nil
+}
+
+// ValidateEvent provides validation checks for the event name of a webhook
+func ValidateEvent(eventName string) error {
+
+	if stringInSlice(eventName, allowedEvents) == false {
+		return fmt.Errorf("Event: %s is an invalid event. Allowed events are: %s", eventName, allowedEvents)
+	}
+
+	return nil
+}
+
+func stringInSlice(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The CLI has been extended to allow working with CLC webhooks. A new
webhook resource type has been added to the CLi and it contains the following
operations:
    - list
    - delete
    - add-targeturi
    - delete-targeturi
    - update
Further information can be found here:
https://www.ctl.io/api-docs/v2/#webhooks-configuring-webhooks-and-consuming-notifications

Resolves: #60
Signed-off-by: Richard Case <richard.case@outlook.com>