### PR TITLE
Various fixes - cross dc, get server and server create

### DIFF
--- a/init.go
+++ b/init.go
@@ -1941,7 +1941,7 @@ func init() {
 	})
 	registerCommandBase(&crossdc_firewall.ListReq{}, &[]crossdc_firewall.Entity{}, commands.CommandExcInfo{
 		Verb:     "GET",
-		Url:      "https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{accountAlias}/{DataCenter}?destinationAccount={DestinationAccountAlias}",
+		Url:      "https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{accountAlias}/{DataCenter}?destinationAccountId={DestinationAccountAlias}",
 		Resource: "crossdc-firewall-policy",
 		Command:  "list",
 		Help: help.Command{

--- a/init.go
+++ b/init.go
@@ -1374,6 +1374,24 @@ func init() {
 			},
 		},
 	})
+	registerCommandBase(&datacenter.GetBMCapReq{}, &datacenter.GetBMCapRes{}, commands.CommandExcInfo{
+		Verb:     "GET",
+		Url:      "https://api.ctl.io/v2/datacenters/{accountAlias}/{DataCenter}/bareMetalCapabilities",
+		Resource: "data-center",
+		Command:  "get-baremetal-capabilities",
+		Help: help.Command{
+			Brief: []string{
+				"Gets the list of bare metal capabilities that a specific data center supports for a given account,",
+				"including the list of configuration types and the list of supported operating systems.",
+			},
+			Arguments: []help.Argument{
+				{
+					"--data-center",
+					[]string{"Required. Short string representing the data center you are querying."},
+				},
+			},
+		},
+	})
 
 	registerCommandBase(&network.ListReq{}, &[]network.Entity{}, commands.CommandExcInfo{
 		Verb:     "GET",

--- a/init.go
+++ b/init.go
@@ -193,14 +193,15 @@ func init() {
 					"--configuration-id",
 					[]string{
 						"Only required for bare metal servers. Specifies the identifier for the specific configuration type of bare metal server to deploy.",
-						"Ignored for standard and hyperscale servers.",
+						"The list of valid bare metal configuration id's can be found by calling the 'clc data-center get-baremetal-capabilities' command.",
+						"Ignored for standard and hyperscale servers. ",
 					},
 				},
 				{
 					"--os-type",
 					[]string{
-						"Only required for bare metal servers. Specifies the OS to provision with the bare metal server. Currently, the only supported OS types",
-						"are redHat6_64Bit, centOS6_64Bit, windows2012R2Standard_64Bit.",
+						"Only required for bare metal servers. Specifies the OS to provision with the bare metal server. The list of valid operating",
+						"systems can be found by calling the 'clc data-center get-baremetal-capabilities' command.",
 						"Ignored for standard and hyperscale servers.",
 					},
 				},

--- a/models/datacenter/get_baremetal_capabilities.go
+++ b/models/datacenter/get_baremetal_capabilities.go
@@ -1,0 +1,41 @@
+package datacenter
+
+type GetBMCapReq struct {
+	DataCenter string `valid:"required" URIParam:"yes"`
+}
+
+type GetBMCapRes struct {
+	SKUs             []SKU             `json:"skus"`
+	OperatingSystems []OperatingSystem `json:"operatingSystems"`
+}
+
+type SKU struct {
+	ID           string    `json:"id"`
+	HourlyRate   float32   `json:"hourlyRate"`
+	Availability string    `json:"availability"`
+	Memory       []Memory  `json:"memory"`
+	Processor    Processor `json:"processor"`
+	Storage      []Storage `json:"storage"`
+}
+
+type Memory struct {
+	CapacityInGB int `json:"capacityGB"`
+}
+
+type Processor struct {
+	Sockets        int    `json:"sockets"`
+	CoresPerSocket int    `json:"coresPerSocket"`
+	Description    string `json:"description"`
+}
+
+type Storage struct {
+	Type         string `json:"type"`
+	CapacityInGB int    `json:"capacityGB"`
+	SpeedInRPM   int    `json:"speedRpm"`
+}
+
+type OperatingSystem struct {
+	Type                string  `json:"type"`
+	Description         string  `json:"description"`
+	HourlyRatePerSocket float32 `json:"hourlyRatePerSocket"`
+}

--- a/models/server/create.go
+++ b/models/server/create.go
@@ -28,9 +28,9 @@ type CreateReq struct {
 	IpAddress              string             `json:",omitempty"`
 	RootPassword           string             `json:"Password,omitempty"`
 	SourceServerPassword   string             `json:",omitempty"`
-	Cpu                    int64              `valid:"required"`
+	Cpu                    int64              `json:",omitempty`
 	CpuAutoscalePolicyId   string             `json:",omitempty"`
-	MemoryGb               int64              `valid:"required"`
+	MemoryGb               int64              `json:",omitempty`
 	Type                   string             `valid:"required" oneOf:"standard,hyperscale,bareMetal"`
 	AntiAffinityPolicyId   string             `json:",omitempty"`
 	AntiAffinityPolicyName string             `json:",omitempty"`
@@ -44,15 +44,24 @@ type CreateReq struct {
 }
 
 func (c *CreateReq) Validate() error {
-	serverIdValues := []string{c.SourceServerId, c.SourceServerName, c.TemplateName}
-	numNonEmpty := 0
-	for _, item := range serverIdValues {
-		if item != "" {
-			numNonEmpty++
+	if c.Type == "standard" || c.Type == "hyperscale" {
+		if c.Cpu == 0 {
+			return fmt.Errorf("Cpu: required for standard and hyperscale servers.")
 		}
-	}
-	if numNonEmpty > 1 || numNonEmpty == 0 {
-		return fmt.Errorf("Exactly one parameter from the following: source-server-id, source-server-name, template-name must be specified.")
+		if c.MemoryGb == 0 {
+			return fmt.Errorf("MemoryGb: required for standard and hyperscale servers.")
+		}
+
+		serverIdValues := []string{c.SourceServerId, c.SourceServerName, c.TemplateName}
+		numNonEmpty := 0
+		for _, item := range serverIdValues {
+			if item != "" {
+				numNonEmpty++
+			}
+		}
+		if numNonEmpty > 1 || numNonEmpty == 0 {
+			return fmt.Errorf("Exactly one parameter from the following: source-server-id, source-server-name, template-name must be specified.")
+		}
 	}
 
 	if (c.GroupName == "") == (c.GroupId == "") {

--- a/models/server/entities.go
+++ b/models/server/entities.go
@@ -37,23 +37,26 @@ type PackageDef struct {
 }
 
 type Details struct {
-	IpAddresses       []IPAddresses
-	AlertPolicies     []alert.AlertPolicy
-	Cpu               int64
-	DiskCount         int64
-	HostName          string
-	InMaintenanceMode bool
-	MemoryMB          int64
-	PowerState        string
-	StorageGB         int64
-	Disks             []Disk
-	Partitions        []Partition
-	Snapshots         []Snapshot
-	CustomFields      []customfields.FullDef
+	IpAddresses          []IPAddresses
+	SecondaryIPAddresses []IPAddresses
+	AlertPolicies        []alert.AlertPolicy
+	Cpu                  int64
+	DiskCount            int64
+	HostName             string
+	InMaintenanceMode    bool
+	MemoryMB             int64
+	PowerState           string
+	StorageGB            int64
+	Disks                []Disk
+	Partitions           []Partition
+	Snapshots            []Snapshot
+	CustomFields         []customfields.FullDef
+	ProcessorDescription string `json:",omitempty"`
+	StorageDescription   string `json:",omitempty"`
 }
 
 type IPAddresses struct {
-	Public   string
+	Public   string `json:",omitempty"`
 	Internal string
 }
 

--- a/models/server/entities.go
+++ b/models/server/entities.go
@@ -53,6 +53,7 @@ type Details struct {
 	CustomFields         []customfields.FullDef
 	ProcessorDescription string `json:",omitempty"`
 	StorageDescription   string `json:",omitempty"`
+	IsManagedBackup      bool   `json:",omitempty"`
 }
 
 type IPAddresses struct {

--- a/models/server/get.go
+++ b/models/server/get.go
@@ -17,6 +17,7 @@ type GetRes struct {
 	IsTemplate  bool
 	LocationId  string
 	OsType      string
+	IsManagedOS bool
 	Os          string
 	Status      string
 	Details     Details

--- a/models/server/update.go
+++ b/models/server/update.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/centurylinkcloud/clc-go-cli/base"
 	"github.com/centurylinkcloud/clc-go-cli/models/customfields"
 	"github.com/centurylinkcloud/clc-go-cli/models/group"
@@ -141,7 +142,7 @@ func (ur *UpdateReq) ApplyDefaultBehaviour() error {
 		}
 		ur.PatchOperation = append(ur.PatchOperation, op)
 	}
-	if len(ur.Disks.Add) != 0 && len(ur.Disks.Keep) != 0 {
+	if len(ur.Disks.Add) != 0 || len(ur.Disks.Keep) != 0 {
 		op := ServerPatchOperation{
 			Op:     "set",
 			Member: "disks",


### PR DESCRIPTION
This contains a fix for issue #64 where getting the cross data centre
policies didn't filter as expected when specifying a destination account
alias. Also, fixed issue #67 where the IsManaged and IsManagedBackup
wasn't being returned when getting server details.

A fix for the server update command that allows the disks in the
server to be updated. Previously you had to specify both disks to
keep and disks to add. This isn't always the case and so the changes
makes it possible to either keep disks (and update their size) or add
new disks or both

The server create command has been updated so that the  parameters such as
CPU, MemoryGB, template, Source Server Id are only required for standard and
hyperscale servers. The descriptions for 'configuration-id' and 'os-type'
have been updated to indicate that the expected values can be obtained
by calling data-center get-baremetal-capabilities.

Resolves: #64, #67, #69, #75
